### PR TITLE
Dask Work Manager small fixes

### DIFF
--- a/src/westpa/work_managers/dask.py
+++ b/src/westpa/work_managers/dask.py
@@ -133,7 +133,7 @@ class DaskWorkManager(WorkManager):
                 scheduler_file = self.client.pop('scheduler_file', None)
 
                 if address or scheduler_file:
-                    # cluster created and managed by the user, could be supplied in CLI
+                    # cluster created and managed by the user, could be supplied from CLI
                     self.client = distributed.Client(address=address, scheduler_file=scheduler_file, **self.client)
                     self._local_cluster = self.client.cluster
                     self._own_client = False
@@ -160,7 +160,7 @@ class DaskWorkManager(WorkManager):
                     self._local_cluster.close()
                     self._local_cluster = None
             else:
-                self.client.restart(timeout=5, wait_for_workers=False)
+                self.client.restart(wait_for_workers=False)
 
             super().shutdown()
 

--- a/src/westpa/work_managers/dask.py
+++ b/src/westpa/work_managers/dask.py
@@ -154,16 +154,13 @@ class DaskWorkManager(WorkManager):
                 pass  # Already unregistered
 
             if self._own_client or force:
-                self.client.retire_workers(close_workers=True)
-                self.client.shutdown()
+                self.client.close()
 
                 if self._local_cluster is not None:
-                    for nanny in self._local_cluster.workers.values():
-                        nanny.close(timeout=5, nanny=True)
                     self._local_cluster.close()
                     self._local_cluster = None
             else:
-                self.client.restart(timeout=5)
+                self.client.restart(timeout=5, wait_for_workers=False)
 
             super().shutdown()
 

--- a/src/westpa/work_managers/dask.py
+++ b/src/westpa/work_managers/dask.py
@@ -133,9 +133,10 @@ class DaskWorkManager(WorkManager):
                 scheduler_file = self.client.pop('scheduler_file', None)
 
                 if address or scheduler_file:
-                    # cluster created and managed by the user
+                    # cluster created and managed by the user, could be supplied in CLI
                     self.client = distributed.Client(address=address, scheduler_file=scheduler_file, **self.client)
                     self._local_cluster = self.client.cluster
+                    self._own_client = False
                 else:
                     # cluster created and managed by the work manager
                     self._local_cluster = distributed.LocalCluster(**self.kwargs)
@@ -159,7 +160,7 @@ class DaskWorkManager(WorkManager):
                     self._local_cluster.close()
                     self._local_cluster = None
             else:
-                self.client.retire_workers(close_workers=False)
+                self.client.restart_workers(close_workers=False, remove=False)
 
             super().shutdown()
 

--- a/src/westpa/work_managers/dask.py
+++ b/src/westpa/work_managers/dask.py
@@ -120,7 +120,7 @@ class DaskWorkManager(WorkManager):
         self.kwargs = kwargs
 
         self._own_client = not isinstance(self.client, distributed.Client)
-        self._local_cluster = None
+        self._local_cluster = None if self._own_client else self.client.cluster
 
     @property
     def n_workers(self):
@@ -135,6 +135,7 @@ class DaskWorkManager(WorkManager):
                 if address or scheduler_file:
                     # cluster created and managed by the user
                     self.client = distributed.Client(address=address, scheduler_file=scheduler_file, **self.client)
+                    self._local_cluster = self.client.cluster
                 else:
                     # cluster created and managed by the work manager
                     self._local_cluster = distributed.LocalCluster(**self.kwargs)
@@ -144,16 +145,21 @@ class DaskWorkManager(WorkManager):
             self.client.register_plugin(_ConfigSetter(), name='config_setter')
             self.running = True
 
-    def shutdown(self):
+    def shutdown(self, force=False):
         if self.running:
             self.client.unregister_worker_plugin(name='config_setter')
 
-            if self._own_client:
-                self.client.close(timeout=5)
+            if self._own_client or force:
+                self.client.retire_workers(close_workers=True)
+                self.client.shutdown()
 
-            if self._local_cluster is not None:
-                self._local_cluster.close(timeout=5)
-                self._local_cluster = None
+                if self._local_cluster is not None:
+                    for nanny in self._local_cluster.workers.values():
+                        nanny.close(timeout=5, nanny=True)
+                    self._local_cluster.close()
+                    self._local_cluster = None
+            else:
+                self.client.retire_workers(close_workers=False)
 
             super().shutdown()
 

--- a/src/westpa/work_managers/dask.py
+++ b/src/westpa/work_managers/dask.py
@@ -148,7 +148,10 @@ class DaskWorkManager(WorkManager):
 
     def shutdown(self, force=False):
         if self.running:
-            self.client.unregister_worker_plugin(name='config_setter')
+            try:
+                self.client.unregister_worker_plugin(name='config_setter')
+            except ValueError:
+                pass  # Already unregistered
 
             if self._own_client or force:
                 self.client.retire_workers(close_workers=True)
@@ -160,7 +163,7 @@ class DaskWorkManager(WorkManager):
                     self._local_cluster.close()
                     self._local_cluster = None
             else:
-                self.client.restart_workers(close_workers=False, remove=False)
+                self.client.restart(timeout=5)
 
             super().shutdown()
 

--- a/tests/test_work_managers/test_dask.py
+++ b/tests/test_work_managers/test_dask.py
@@ -55,3 +55,12 @@ class TestDaskWorkManager:
             _ = future.result
         assert isinstance(future.exception, ValueError)
         assert future.done
+
+    def test_assert_work_manager(self, work_manager):
+        '''Check to see if work manager is actually running after'''
+        with work_manager:
+            work_manager.shutdown()
+
+        assert work_manager.running is False  # We exited the work_manager context manager
+        assert work_manager.client.status == 'running'  # Client should be running
+        assert work_manager._local_cluster is not None  # Cluster should be running

--- a/tests/test_work_managers/test_dask.py
+++ b/tests/test_work_managers/test_dask.py
@@ -22,6 +22,7 @@ class TestDaskWorkManager:
             yield work_manager
 
         # Cleanup done during fixture teardown
+        work_manager.shutdown(force=True)
         client.close()
         cluster.close()
 

--- a/tests/test_work_managers/test_environment.py
+++ b/tests/test_work_managers/test_environment.py
@@ -122,4 +122,9 @@ class TestInstantiations(unittest.TestCase):
             result = future.get_result(discard=True)
             assert result
 
+            assert work_manager.running
             assert work_manager.n_workers == 3
+
+        assert work_manager.running is False
+        assert work_manager.client.status == 'closed'
+        assert work_manager._local_cluster is None


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Just some smaller fixes (including tests for work manager shut down-- cluster/client will close in `test_environment.py`, won't do so in `test_dask.py`).

I added the line to `self.client.restart()` for dask after `w_run` shutdown because the queues are still stuck with tasks after w_run is terminated, which is not ideal.  This ensures the workers are reusable for something else after shut down. 

One other thing was, on my workstation, sometimes dask will request like 3 exabytes of memory (and error out, obviously) if I don't set up `--dask-memory-limit`. I don't know exactly why that is the case, except that maybe 'auto' is faulty in those instances. Can't seem to reproduce that anymore.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Add tests for dask shutdown
- [x] Fix bug where cluster/client is provided via CLI, but terminating w_run will shut them down any way.

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/work_managers/dask.py
- [x] tests/test_work_managers/test_dask.py
- [x] tests/test_work_managers/test_environment.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


