### PR TITLE
Amber propagator

### DIFF
--- a/src/westpa/__init__.py
+++ b/src/westpa/__init__.py
@@ -61,7 +61,7 @@ except ImportError:
     pass
 
 try:
-    from .core.propagators._amber import Amberropagator
+    from .core.propagators._amber import AmberPropagator
 except ImportError:
     pass
 

--- a/src/westpa/__init__.py
+++ b/src/westpa/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     'Sink',
     'Propagator',
     'OpenMMPropagator',
+    'Amberropagator'
     'Plugin',
     'TrajectoryTree',
     'Trajectory',
@@ -58,6 +59,13 @@ try:
     from .core.propagators._openmm import OpenMMPropagator
 except ImportError:
     pass
+
+try:
+    from .core.propagators._amber import Amberropagator
+except ImportError:
+    pass
+
+
 
 from .analysis import TrajectoryTree, Trajectory
 

--- a/src/westpa/__init__.py
+++ b/src/westpa/__init__.py
@@ -21,7 +21,7 @@ __all__ = [
     'Propagator',
     'GromacsPropagator',
     'OpenMMPropagator',
-    'AmberPropagator', 
+    'AmberPropagator',
     'Plugin',
     'TrajectoryTree',
     'Trajectory',
@@ -69,8 +69,6 @@ except ImportError:
 
 if shutil.which("sander"):
     from .core.propagators._amber import AmberPropagator
-
-
 
 
 from .analysis import TrajectoryTree, Trajectory

--- a/src/westpa/__init__.py
+++ b/src/westpa/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     'Source',
     'Sink',
     'Propagator',
+    'GromacsPropagator',
     'OpenMMPropagator',
     'Amberropagator' 'Plugin',
     'TrajectoryTree',
@@ -28,6 +29,8 @@ __all__ = [
     'TargetState',
     '_rc',
 ]
+
+import shutil
 
 from .core.state import State
 from .core.segment import Segment
@@ -53,6 +56,9 @@ from .core.resamplers import (
 from .core.simulation import Simulation
 from .core.source_sink import Source, Sink
 from .core.plugins import Plugin
+
+if shutil.which('gmx'):
+    from .core.propagators._gromacs import GromacsPropagator
 
 try:
     from .core.propagators._openmm import OpenMMPropagator

--- a/src/westpa/__init__.py
+++ b/src/westpa/__init__.py
@@ -20,8 +20,7 @@ __all__ = [
     'Sink',
     'Propagator',
     'OpenMMPropagator',
-    'Amberropagator'
-    'Plugin',
+    'Amberropagator' 'Plugin',
     'TrajectoryTree',
     'Trajectory',
     'WESTSystem',
@@ -64,7 +63,6 @@ try:
     from .core.propagators._amber import AmberPropagator
 except ImportError:
     pass
-
 
 
 from .analysis import TrajectoryTree, Trajectory

--- a/src/westpa/__init__.py
+++ b/src/westpa/__init__.py
@@ -21,7 +21,8 @@ __all__ = [
     'Propagator',
     'GromacsPropagator',
     'OpenMMPropagator',
-    'Amberropagator' 'Plugin',
+    'AmberPropagator', 
+    'Plugin',
     'TrajectoryTree',
     'Trajectory',
     'WESTSystem',
@@ -65,10 +66,11 @@ try:
 except ImportError:
     pass
 
-try:
+
+if shutil.which("sander"):
     from .core.propagators._amber import AmberPropagator
-except ImportError:
-    pass
+
+
 
 
 from .analysis import TrajectoryTree, Trajectory

--- a/src/westpa/core/propagators/_amber.py
+++ b/src/westpa/core/propagators/_amber.py
@@ -1,121 +1,90 @@
 import logging
 import subprocess 
-import copy
-import logging
-import os
-import time
-from dataclasses import dataclass
-
-import numpy as np
-import openmm.app
-
 from .base import Propagator
 from westpa.core.state import State
+import time
+import os
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_SEGMENT_DIR_TEMPLATE = 'traj_segs/{n_iter:06d}/{seg_id:06d}'
 DEFAULT_FINAL_STATE_FILENAME = 'final_state.xml'
 
-class Amberropagator(Propagator):
+class AmberPropagator(Propagator):
     """
     Work in progress Amber propagation engine 
-
     """
 
     def __init__(
         self,
         mdin,
+        prmtop,
         inpcrd,
+        restart,
         mdcrd,
-        mdout=None,
-        mdinfo=None,
-        prmtop=None,
-        refc=None,
-        mtmd=None,
-        mdcrt=None,
-        inptraj=None,
-        mdvel=None,
-        mdfrc=None,
-        mden=None,
-        restrt=None,
-        inpdip=None,
-        rstdip=None,
-        cpin=None,
-        cpestrt=None,
-        cpout=None,
-        cein=None,
-        ceresrst=None,
-        cecout=None,
-        evbin=None,
-        suffix=None,
-        segment_dir_template=None,
-        final_state_filename=None,
-        root_seed=None,
+        amber_flags=None,
+        pmemd=True,
+        sander=False,
+        segment_dir_template=DEFAULT_SEGMENT_DIR_TEMPLATE,
+        final_state_filename=DEFAULT_FINAL_STATE_FILENAME,
         **kwargs
     ):
         super().__init__()
-        self.mdin = mdin
-        self.mdout = mdout
-        self.mdinfo = mdinfo
+        self.mdin =mdin
         self.prmtop = prmtop
-        self.inpcrd = inpcrd
-        self.refc = refc
-        self.mtmd = mtmd
-        self.mdcrt = mdcrt
-        self.inptraj = inptraj
-        self.mdvel = mdvel
-        self.mdfrc = mdfrc
-        self.mden = mden
-        self.restrt = restrt
-        self.inpdip = inpdip
-        self.rstdip = rstdip
-        self.cpin = cpin
-        self.cpestrt = cpestrt
-        self.cpout = cpout
-        self.cein = cein
-        self.ceresrst = ceresrst
-        self.cecout = cecout
-        self.evbin = evbin
-        self.suffix = suffix
-        #!Figure out if **kwargs
+        self.restart = restart
+        self.mdcrd = mdcrd
+        self.amber_flags = amber_flags
+        
+        self.pmemd = pmemd
+        self.sander = sander
+        self.segment_dir_template = segment_dir_template
+        self.final_state_filename = final_state_filename
+        self.validate_inputs()
 
-        #self.platform_properties = platform_properties
-        #self.segment_dir_template = os.path.abspath(segment_dir_template or DEFAULT_SEGMENT_DIR_TEMPLATE)
-        #self.final_state_filename = final_state_filename or DEFAULT_FINAL_STATE_FILENAME
-        #self._reports = []
+    def validate_inputs(self):
+        if self.pmemd and self.sander:
+            raise ValueError("Cannot specify both pmemd and sander as True. Please choose one.")
+        if not self.pmemd and not self.sander:
+            raise ValueError("Must specify either pmemd or sander as True. Please choose one.")
 
+    def construct_command(self): #TODO: Need to pass the input flags explicitly not just the dictionary 
+        #!segment check the init point type NEWTRAJ (possibly one flag for both)
+        #! check irest flag 
+        if self.pmemd:
+            cmd=["pmemd.cuda"]
+        elif self.sander:
+            cmd=["sander"]
+        if self.amber_flags:
+            for flag_key, flag_value in self.amber_flags.items():
+                if flag_value is None:
+                    continue    
+                if len(flag_key) == 1:
+                    cmd.append(f"-{flag_key} {flag_value}")
+                else:
+                    cmd.append(f"--{flag_key} {flag_value}")
+        return cmd
 
-    def propagate(self,segment):
+    def propagate(self,segment): #!would need to list all gpus and work manager index so taht there is no overlap within runseg
         start_time = time.time()
-        #Command construction
-        input_flags=vars(self)
-        cmd=["pmemd.cuda"]
-        for k, v in input_flags.items():
-            
-            if v is None:
-                #print(k) #all the ones that are none
-                continue
 
-            if k == "_root_seed":
-                continue
-            if k == "_block_size":
-                continue
-            
-            cmd.append(f"--{k} {v}")
-        #print(cmd)
+        cmd=self.construct_command()
 
-        #command execution
-        res = subprocess.run(cmd, capture_output=True, text=True)
+        #print(f"Executing command: {cmd} ")
+        
+        #Execute the command and capture output, handling exceptions
+        try:
+            res = subprocess.run(, capture_output=True, text=True) #!need to pass the variables here for amber to not use redudnat gpu usage
+        except Exception as e:
+            segment.mark_as_failed(str(e))
+            return segment
 
-        state=segment.initial_state.file #file in storage that md will pick up from #!This is specified with input flag, c 
+
         segment_dir = self.segment_dir_template.format(n_iter=segment.n_iter, seg_id=segment.seg_id)
         os.makedirs(segment_dir)
-
-        final_state_file = os.path.join(segment_dir, self.mdcrd) #aka seg.nc 
+        final_state_file = os.path.join(segment_dir,self.restart) 
         segment.final_state = State(file=final_state_file)
         segment.walltime = time.time() - start_time #done
-
         return segment
 
 

--- a/src/westpa/core/propagators/_amber.py
+++ b/src/westpa/core/propagators/_amber.py
@@ -8,18 +8,37 @@ import os
 import numpy as np
 import shutil
 
+#Todo: Suggest adding a propagatorerror
+#from .base import Propagator, PropagatorError
+#Reads as: westpa.core.propagators.base.PropagatorError: Engine None was not found.
+from ..sim_manager import PropagationError
+#Reads as: westpa.core.sim_manager.PropagationError: Engine None was not found.
+
 logger = logging.getLogger(__name__)
 
-#Operate under the assumption that environment where subprocess is run has the cuda visible devices set
-
-#Basic tests tbd:'
-# utilize test ref, 
-#utilize dummy segment, and use the input flags, to check if outputs are produced (do in tmp directory)
-
-
 class AmberPropagator(SubprocessPropagator):
+    """Molecular dynamics propagator built for the `Amber <https://ambermd.org/>`_ molecular simulation package.
+
+    Parameters
+    ----------
+    md_parameters : dict
+        Dictionary of control parameters written to the Amber control input
+        (``mdin``) file.
+
+    prmtop_file : str
+        Path to the Amber topology (``.prmtop``) file.
+
+    engine : str, optional
+        Amber molecular dynamics engine to use for propagation. Supported
+        values are:
+
+        - ``sander``
+        - ``pmemd``
+        - ``pmemd.cuda``
+
+        Default is ``"sander"``.
+    """
     DEFAULT_FINAL_STATE_FILENAME = 'restrt'
-    DEFAULT_TRAJECTORY_FILENAME = 'mdcrd'
     def __init__(
             self,
 
@@ -31,42 +50,51 @@ class AmberPropagator(SubprocessPropagator):
         super().__init__(final_state_filename=self.DEFAULT_FINAL_STATE_FILENAME, **kwargs)
         self.md_parameters = md_parameters
         self.prmtop_file = os.path.abspath(prmtop_file)
-        self.engine = engine
+        self.engine = engine.lower()
 
     def get_command(self, segment, rng):
         
         md_parameters=self.md_parameters.copy()  # Make a copy to avoid modifying the original dictionary
 
-        # ===== start command construction handeling =====
-        engine: str | None=shutil.which(self.engine)
-        if engine not in ["sander","pmemd"]:
-            raise RuntimeError(f"Engine {self.engine} was not found.")
+        # Check engine option is allowed
+        if self.engine.lower() not in ["sander","pmemd","pmemd.cuda"]:
+            raise PropagationError(f"Engine {self.engine} is not a valid enginge option.")
+            raise PropagatorError(f"Engine {self.engine} was not found.")
+
+        # ===== start command construction handling =====
+        if not shutil.which(self.engine):
+            raise PropagationError(f"Engine {self.engine} not found in PATH.")
+            #raise PropagatorError(f"Engine {self.engine} was not found.")
+
         cmd=self.engine
         topology_flag= f"-p {self.prmtop_file}"
         input_coord_flag=f"-c {segment.initial_state.file}"
         cmd=(cmd+" "+topology_flag+" "+input_coord_flag)
-        # ===== end command construction handeling =====
+        # ===== end command construction handling =====
 
 
-        # ===== start mdin handeling =====
+        # ===== start mdin handling =====
+        md_parameters['ig'] = rng.integers(2 ** 16, dtype=np.uint16)
         if segment.initpoint_type == segment.InitPointType.NEWTRAJ:
             md_parameters['irest'] = 0
             md_parameters['ntx'] = 1
-            md_parameters['ig'] = rng.integers(2**16, dtype=np.uint16)
         elif segment.initpoint_type == segment.InitPointType.CONTINUES:
             md_parameters['irest'] = 1
             md_parameters['ntx'] = 5
-            md_parameters['ig'] = rng.integers(2**16, dtype=np.uint16)
+
         
         md_parameters_string = ',\n'.join(f'{k} = {v}' for k, v in md_parameters.items())
         title=f"Segment run n_iter={segment.n_iter}, seg_id={segment.seg_id}"
         md_parameters_string = f"{title}\n&cntrl\n{md_parameters_string}\n/\n"
-        # ===== end mdin handeling =====
+        # ===== end mdin handling =====
 
         bash_script=f"""
-printf {cmd} > cmd.txt
 printf "{md_parameters_string}" > mdin
 {cmd} 
 """
         #returning a bash script that will be run
         return bash_script
+
+#Todo: Basic tests tbd:'
+# utilize test ref,
+# utilize dummy segment, and use the input flags, to check if outputs are produced (do in tmp directory)

--- a/src/westpa/core/propagators/_amber.py
+++ b/src/westpa/core/propagators/_amber.py
@@ -8,13 +8,16 @@ import os
 import numpy as np
 import shutil
 
-#Todo: Suggest adding a propagatorerror
+# Todo: Suggest adding a propagatorerror
 from .base import Propagator, PropagatorError
-#Reads as: westpa.core.propagators.base.PropagatorError: Engine None was not found.
+
+# Reads as: westpa.core.propagators.base.PropagatorError: Engine None was not found.
 from ..sim_manager import PropagationError
-#Reads as: westpa.core.sim_manager.PropagationError: Engine None was not found.
+
+# Reads as: westpa.core.sim_manager.PropagationError: Engine None was not found.
 
 logger = logging.getLogger(__name__)
+
 
 class AmberPropagator(SubprocessPropagator):
     """Molecular dynamics propagator built for the `Amber <https://ambermd.org/>`_ molecular simulation package.
@@ -38,14 +41,15 @@ class AmberPropagator(SubprocessPropagator):
 
         Default is ``"sander"``.
     """
-    DEFAULT_FINAL_STATE_FILENAME = 'restrt'
-    def __init__(
-            self,
 
-            md_parameters:dict, #dictionary of md input parameters that go in the mdin file
-            prmtop_file:str, #path to topology file
-            engine:str = "sander", 
-            **kwargs
+    DEFAULT_FINAL_STATE_FILENAME = 'restrt'
+
+    def __init__(
+        self,
+        md_parameters: dict,  # dictionary of md input parameters that go in the mdin file
+        prmtop_file: str,  # path to topology file
+        engine: str = "sander",
+        **kwargs,
     ):
         super().__init__(final_state_filename=self.DEFAULT_FINAL_STATE_FILENAME, **kwargs)
         self.md_parameters = md_parameters
@@ -53,11 +57,11 @@ class AmberPropagator(SubprocessPropagator):
         self.engine = engine.lower()
 
     def get_command(self, segment, rng):
-        
-        md_parameters=self.md_parameters.copy()  # Make a copy to avoid modifying the original dictionary
+
+        md_parameters = self.md_parameters.copy()  # Make a copy to avoid modifying the original dictionary
 
         # Check engine option is allowed
-        if self.engine.lower() not in ["sander","pmemd","pmemd.cuda"]:
+        if self.engine.lower() not in ["sander", "pmemd", "pmemd.cuda"]:
             raise PropagationError(f"Engine {self.engine} is not a valid enginge option.")
             raise PropagatorError(f"Engine {self.engine} was not found.")
 
@@ -65,15 +69,14 @@ class AmberPropagator(SubprocessPropagator):
         if not shutil.which(self.engine):
             raise PropagatorError(f"Engine {self.engine} not found in PATH.")
 
-        cmd=self.engine
-        topology_flag= f"-p {self.prmtop_file}"
-        input_coord_flag=f"-c {segment.initial_state.file}"
-        cmd=(cmd+" "+topology_flag+" "+input_coord_flag)
+        cmd = self.engine
+        topology_flag = f"-p {self.prmtop_file}"
+        input_coord_flag = f"-c {segment.initial_state.file}"
+        cmd = cmd + " " + topology_flag + " " + input_coord_flag
         # ===== end command construction handling =====
 
-
         # ===== start mdin handling =====
-        md_parameters['ig'] = rng.integers(2 ** 16, dtype=np.uint16)
+        md_parameters['ig'] = rng.integers(2**16, dtype=np.uint16)
         if segment.initpoint_type == segment.InitPointType.NEWTRAJ:
             md_parameters['irest'] = 0
             md_parameters['ntx'] = 1
@@ -81,19 +84,19 @@ class AmberPropagator(SubprocessPropagator):
             md_parameters['irest'] = 1
             md_parameters['ntx'] = 5
 
-        
         md_parameters_string = ',\n'.join(f'{k} = {v}' for k, v in md_parameters.items())
-        title=f"Segment run n_iter={segment.n_iter}, seg_id={segment.seg_id}"
+        title = f"Segment run n_iter={segment.n_iter}, seg_id={segment.seg_id}"
         md_parameters_string = f"{title}\n&cntrl\n{md_parameters_string}\n/\n"
         # ===== end mdin handling =====
 
-        bash_script=f"""
+        bash_script = f"""
 printf "{md_parameters_string}" > mdin
-{cmd} 
+{cmd}
 """
-        #returning a bash script that will be run
+        # returning a bash script that will be run
         return bash_script
 
-#Todo: Basic tests tbd:'
+
+# Todo: Basic tests tbd:'
 # utilize test ref,
 # utilize dummy segment, and use the input flags, to check if outputs are produced (do in tmp directory)

--- a/src/westpa/core/propagators/_amber.py
+++ b/src/westpa/core/propagators/_amber.py
@@ -60,7 +60,7 @@ class AmberPropagator(SubprocessPropagator):
 
         # Check engine option is allowed
         if self.engine.lower() not in ["sander", "pmemd", "pmemd.cuda"]:
-            raise PropagationError(f"Engine {self.engine} is not a valid enginge option.")
+            raise PropagationError(f"Engine {self.engine} is not a valid engine option.")
             raise PropagatorError(f"Engine {self.engine} was not found.")
 
         # ===== start command construction handling =====

--- a/src/westpa/core/propagators/_amber.py
+++ b/src/westpa/core/propagators/_amber.py
@@ -1,5 +1,5 @@
 import logging
-import subprocess 
+import subprocess
 from .base import Propagator
 from westpa.core.state import State
 import time
@@ -12,7 +12,7 @@ DEFAULT_FINAL_STATE_FILENAME = 'final_state.xml'
 
 class AmberPropagator(Propagator):
     """
-    Work in progress Amber propagation engine 
+    Work in progress Amber propagation engine
     """
 
     def __init__(
@@ -35,7 +35,7 @@ class AmberPropagator(Propagator):
         self.restart = restart
         self.mdcrd = mdcrd
         self.amber_flags = amber_flags
-        
+
         self.pmemd = pmemd
         self.sander = sander
         self.segment_dir_template = segment_dir_template
@@ -48,9 +48,9 @@ class AmberPropagator(Propagator):
         if not self.pmemd and not self.sander:
             raise ValueError("Must specify either pmemd or sander as True. Please choose one.")
 
-    def construct_command(self): #TODO: Need to pass the input flags explicitly not just the dictionary 
+    def construct_command(self): #TODO: Need to pass the input flags explicitly not just the dictionary
         #!segment check the init point type NEWTRAJ (possibly one flag for both)
-        #! check irest flag 
+        #! check irest flag
         if self.pmemd:
             cmd=["pmemd.cuda"]
         elif self.sander:
@@ -58,7 +58,7 @@ class AmberPropagator(Propagator):
         if self.amber_flags:
             for flag_key, flag_value in self.amber_flags.items():
                 if flag_value is None:
-                    continue    
+                    continue
                 if len(flag_key) == 1:
                     cmd.append(f"-{flag_key} {flag_value}")
                 else:
@@ -71,7 +71,7 @@ class AmberPropagator(Propagator):
         cmd=self.construct_command()
 
         #print(f"Executing command: {cmd} ")
-        
+
         #Execute the command and capture output, handling exceptions
         try:
             res = subprocess.run(, capture_output=True, text=True) #!need to pass the variables here for amber to not use redudnat gpu usage
@@ -82,7 +82,7 @@ class AmberPropagator(Propagator):
 
         segment_dir = self.segment_dir_template.format(n_iter=segment.n_iter, seg_id=segment.seg_id)
         os.makedirs(segment_dir)
-        final_state_file = os.path.join(segment_dir,self.restart) 
+        final_state_file = os.path.join(segment_dir,self.restart)
         segment.final_state = State(file=final_state_file)
         segment.walltime = time.time() - start_time #done
         return segment
@@ -94,4 +94,3 @@ class AmberPropagator(Propagator):
 
 
 #$PMEMD -O -p parent.prmtop -i prod.in -c parent.rst -o seg.out -inf seg.nfo -l seg.log -x seg.nc -r seg.rst || exit 1
-

--- a/src/westpa/core/propagators/_amber.py
+++ b/src/westpa/core/propagators/_amber.py
@@ -8,18 +8,37 @@ import os
 import numpy as np
 import shutil
 
+#Todo: Suggest adding a propagatorerror
+from .base import Propagator, PropagatorError
+#Reads as: westpa.core.propagators.base.PropagatorError: Engine None was not found.
+from ..sim_manager import PropagationError
+#Reads as: westpa.core.sim_manager.PropagationError: Engine None was not found.
+
 logger = logging.getLogger(__name__)
 
-#Operate under the assumption that environment where subprocess is run has the cuda visible devices set
-
-#Basic tests tbd:'
-# utilize test ref, 
-#utilize dummy segment, and use the input flags, to check if outputs are produced (do in tmp directory)
-
-
 class AmberPropagator(SubprocessPropagator):
+    """Molecular dynamics propagator built for the `Amber <https://ambermd.org/>`_ molecular simulation package.
+
+    Parameters
+    ----------
+    md_parameters : dict
+        Dictionary of control parameters written to the Amber control input
+        (``mdin``) file.
+
+    prmtop_file : str
+        Path to the Amber topology (``.prmtop``) file.
+
+    engine : str, optional
+        Amber molecular dynamics engine to use for propagation. Supported
+        values are:
+
+        - ``sander``
+        - ``pmemd``
+        - ``pmemd.cuda``
+
+        Default is ``"sander"``.
+    """
     DEFAULT_FINAL_STATE_FILENAME = 'restrt'
-    DEFAULT_TRAJECTORY_FILENAME = 'mdcrd'
     def __init__(
             self,
 
@@ -31,42 +50,50 @@ class AmberPropagator(SubprocessPropagator):
         super().__init__(final_state_filename=self.DEFAULT_FINAL_STATE_FILENAME, **kwargs)
         self.md_parameters = md_parameters
         self.prmtop_file = os.path.abspath(prmtop_file)
-        self.engine = engine
+        self.engine = engine.lower()
 
     def get_command(self, segment, rng):
         
         md_parameters=self.md_parameters.copy()  # Make a copy to avoid modifying the original dictionary
 
-        # ===== start command construction handeling =====
-        engine: str | None=shutil.which(self.engine)
-        if engine not in ["sander","pmemd"]:
-            raise RuntimeError(f"Engine {self.engine} was not found.")
+        # Check engine option is allowed
+        if self.engine.lower() not in ["sander","pmemd","pmemd.cuda"]:
+            raise PropagationError(f"Engine {self.engine} is not a valid enginge option.")
+            raise PropagatorError(f"Engine {self.engine} was not found.")
+
+        # ===== start command construction handling =====
+        if not shutil.which(self.engine):
+            raise PropagatorError(f"Engine {self.engine} not found in PATH.")
+
         cmd=self.engine
         topology_flag= f"-p {self.prmtop_file}"
         input_coord_flag=f"-c {segment.initial_state.file}"
         cmd=(cmd+" "+topology_flag+" "+input_coord_flag)
-        # ===== end command construction handeling =====
+        # ===== end command construction handling =====
 
 
-        # ===== start mdin handeling =====
+        # ===== start mdin handling =====
+        md_parameters['ig'] = rng.integers(2 ** 16, dtype=np.uint16)
         if segment.initpoint_type == segment.InitPointType.NEWTRAJ:
             md_parameters['irest'] = 0
             md_parameters['ntx'] = 1
-            md_parameters['ig'] = rng.integers(2**16, dtype=np.uint16)
         elif segment.initpoint_type == segment.InitPointType.CONTINUES:
             md_parameters['irest'] = 1
             md_parameters['ntx'] = 5
-            md_parameters['ig'] = rng.integers(2**16, dtype=np.uint16)
+
         
         md_parameters_string = ',\n'.join(f'{k} = {v}' for k, v in md_parameters.items())
         title=f"Segment run n_iter={segment.n_iter}, seg_id={segment.seg_id}"
         md_parameters_string = f"{title}\n&cntrl\n{md_parameters_string}\n/\n"
-        # ===== end mdin handeling =====
+        # ===== end mdin handling =====
 
         bash_script=f"""
-printf {cmd} > cmd.txt
 printf "{md_parameters_string}" > mdin
 {cmd} 
 """
         #returning a bash script that will be run
         return bash_script
+
+#Todo: Basic tests tbd:'
+# utilize test ref,
+# utilize dummy segment, and use the input flags, to check if outputs are produced (do in tmp directory)

--- a/src/westpa/core/propagators/_amber.py
+++ b/src/westpa/core/propagators/_amber.py
@@ -1,29 +1,95 @@
 import logging
 import subprocess
 from .base import Propagator
-from westpa.core.state import State
+from .subprocess import SubprocessPropagator
+from ..state import State
 import time
 import os
+import numpy as np
+import shutil
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_SEGMENT_DIR_TEMPLATE = 'traj_segs/{n_iter:06d}/{seg_id:06d}'
-DEFAULT_FINAL_STATE_FILENAME = 'final_state.xml'
+#Operate under the assumption that enviroment where subprocess is run has the cudavisiible devices set
 
+#Basic tests tbd:
+# utilize test ref, 
+#utilize dummy segment, and use the input flags, to check if outputs are produced (do in tmp directory)
+
+
+class AmberPropagator(SubprocessPropagator):
+    DEFAULT_FINAL_STATE_FILENAME = 'restrt'
+    def __init__(
+            self,
+            md_parameters:dict, #dictionary of md input parameters that go in the mdin file
+            prmtop_file:str, #path to topology file
+            engine:str = "sander", 
+            **kwargs
+    ):
+        super().__init__(final_state_filename=self.DEFAULT_FINAL_STATE_FILENAME, **kwargs)
+        self.md_parameters = md_parameters
+        self.prmtop_file = os.path.abspath(prmtop_file)
+        self.engine = engine
+
+    def get_command(self, segment, rng):
+        
+        md_parameters=self.md_parameters.copy()  # Make a copy to avoid modifying the original dictionary
+
+        # ===== start command construction handeling =====
+        engine=shutil.which(self.engine)
+        cmd=[engine]
+        topology_flag= f"-p {self.prmtop_file}"
+        cmd=cmd.append(topology_flag)
+        # ===== end command construction handeling =====
+
+
+        # ===== start mdin handeling =====
+        if segment.initpoint_type == segment.InitPointType.NEWTRAJ:
+            md_parameters['irest'] = 0
+            md_parameters['ntx'] = 1
+            md_parameters['ig'] = rng.integers(2**16, dtype=np.uint16)
+        elif segment.initpoint_type == segment.InitPointType.CONTINUES:
+            md_parameters['irest'] = 1
+            md_parameters['ntx'] = 5
+            md_parameters['ig'] = rng.integers(2**16, dtype=np.uint16)
+        
+        md_parameters_string = ',\n'.join(f'{k} = {v}' for k, v in md_parameters.items())
+        title=f"Segment run n_iter={segment.n_iter}, seg_id={segment.seg_id}"
+        md_parameters_string = f"{title}\n&cntrl\n{md_parameters_string}\n/"
+        # ===== end mdin handeling =====
+
+        #returning a bash script that will be run
+        return f"""
+printf "{md_parameters_string}" > mdin
+{cmd} 
+        """
+
+
+
+
+
+
+
+
+
+
+
+
+#TODO: check if there are other propagator engine, 
 class AmberPropagator(Propagator):
     """
     Work in progress Amber propagation engine
     """
 
-    def __init__(
+    def __init__( #constructor (in name)
         self,
         mdin,
-        prmtop,
+        prmtop, #!combine an determine if inpcrd is needed to construct propagator
         inpcrd,
         restart,
-        mdcrd,
+        mdcrd, #! Combine, final state file flag instead, then determine what type it is
         amber_flags=None,
-        pmemd=True,
+        pmemd=True, #!relace with engine option that defaults, engine will be string, can be replaced by user
         sander=False,
         segment_dir_template=DEFAULT_SEGMENT_DIR_TEMPLATE,
         final_state_filename=DEFAULT_FINAL_STATE_FILENAME,
@@ -51,10 +117,13 @@ class AmberPropagator(Propagator):
     def construct_command(self): #TODO: Need to pass the input flags explicitly not just the dictionary
         #!segment check the init point type NEWTRAJ (possibly one flag for both)
         #! check irest flag
+
+        #!change such that the user specifies the engine
         if self.pmemd:
             cmd=["pmemd.cuda"]
         elif self.sander:
             cmd=["sander"]
+
         if self.amber_flags:
             for flag_key, flag_value in self.amber_flags.items():
                 if flag_value is None:
@@ -63,6 +132,7 @@ class AmberPropagator(Propagator):
                     cmd.append(f"-{flag_key} {flag_value}")
                 else:
                     cmd.append(f"--{flag_key} {flag_value}")
+        
         return cmd
 
     def propagate(self,segment): #!would need to list all gpus and work manager index so taht there is no overlap within runseg
@@ -74,7 +144,7 @@ class AmberPropagator(Propagator):
 
         #Execute the command and capture output, handling exceptions
         try:
-            res = subprocess.run(, capture_output=True, text=True) #!need to pass the variables here for amber to not use redudnat gpu usage
+            res = subprocess.run(cmd, capture_output=True, text=True) #!need to pass the variables here for amber to not use redudnat gpu usage
         except Exception as e:
             segment.mark_as_failed(str(e))
             return segment

--- a/src/westpa/core/propagators/_amber.py
+++ b/src/westpa/core/propagators/_amber.py
@@ -1,8 +1,5 @@
 import logging
-import subprocess
 from .subprocess import SubprocessPropagator
-from ..state import State
-import time
 import os
 import numpy as np
 import shutil

--- a/src/westpa/core/propagators/_amber.py
+++ b/src/westpa/core/propagators/_amber.py
@@ -10,17 +10,19 @@ import shutil
 
 logger = logging.getLogger(__name__)
 
-#Operate under the assumption that enviroment where subprocess is run has the cudavisiible devices set
+#Operate under the assumption that environment where subprocess is run has the cuda visible devices set
 
-#Basic tests tbd:
+#Basic tests tbd:'
 # utilize test ref, 
 #utilize dummy segment, and use the input flags, to check if outputs are produced (do in tmp directory)
 
 
 class AmberPropagator(SubprocessPropagator):
     DEFAULT_FINAL_STATE_FILENAME = 'restrt'
+    DEFAULT_TRAJECTORY_FILENAME = 'mdcrd'
     def __init__(
             self,
+
             md_parameters:dict, #dictionary of md input parameters that go in the mdin file
             prmtop_file:str, #path to topology file
             engine:str = "sander", 
@@ -36,10 +38,13 @@ class AmberPropagator(SubprocessPropagator):
         md_parameters=self.md_parameters.copy()  # Make a copy to avoid modifying the original dictionary
 
         # ===== start command construction handeling =====
-        engine=shutil.which(self.engine)
-        cmd=[engine]
+        engine: str | None=shutil.which(self.engine)
+        if engine not in ["sander","pmemd"]:
+            raise RuntimeError(f"Engine {self.engine} was not found.")
+        cmd=self.engine
         topology_flag= f"-p {self.prmtop_file}"
-        cmd=cmd.append(topology_flag)
+        input_coord_flag=f"-c {segment.initial_state.file}"
+        cmd=(cmd+" "+topology_flag+" "+input_coord_flag)
         # ===== end command construction handeling =====
 
 
@@ -55,112 +60,13 @@ class AmberPropagator(SubprocessPropagator):
         
         md_parameters_string = ',\n'.join(f'{k} = {v}' for k, v in md_parameters.items())
         title=f"Segment run n_iter={segment.n_iter}, seg_id={segment.seg_id}"
-        md_parameters_string = f"{title}\n&cntrl\n{md_parameters_string}\n/"
+        md_parameters_string = f"{title}\n&cntrl\n{md_parameters_string}\n/\n"
         # ===== end mdin handeling =====
 
-        #returning a bash script that will be run
-        return f"""
+        bash_script=f"""
+printf {cmd} > cmd.txt
 printf "{md_parameters_string}" > mdin
 {cmd} 
-        """
-
-
-
-
-
-
-
-
-
-
-
-
-#TODO: check if there are other propagator engine, 
-class AmberPropagator(Propagator):
-    """
-    Work in progress Amber propagation engine
-    """
-
-    def __init__( #constructor (in name)
-        self,
-        mdin,
-        prmtop, #!combine an determine if inpcrd is needed to construct propagator
-        inpcrd,
-        restart,
-        mdcrd, #! Combine, final state file flag instead, then determine what type it is
-        amber_flags=None,
-        pmemd=True, #!relace with engine option that defaults, engine will be string, can be replaced by user
-        sander=False,
-        segment_dir_template=DEFAULT_SEGMENT_DIR_TEMPLATE,
-        final_state_filename=DEFAULT_FINAL_STATE_FILENAME,
-        **kwargs
-    ):
-        super().__init__()
-        self.mdin =mdin
-        self.prmtop = prmtop
-        self.restart = restart
-        self.mdcrd = mdcrd
-        self.amber_flags = amber_flags
-
-        self.pmemd = pmemd
-        self.sander = sander
-        self.segment_dir_template = segment_dir_template
-        self.final_state_filename = final_state_filename
-        self.validate_inputs()
-
-    def validate_inputs(self):
-        if self.pmemd and self.sander:
-            raise ValueError("Cannot specify both pmemd and sander as True. Please choose one.")
-        if not self.pmemd and not self.sander:
-            raise ValueError("Must specify either pmemd or sander as True. Please choose one.")
-
-    def construct_command(self): #TODO: Need to pass the input flags explicitly not just the dictionary
-        #!segment check the init point type NEWTRAJ (possibly one flag for both)
-        #! check irest flag
-
-        #!change such that the user specifies the engine
-        if self.pmemd:
-            cmd=["pmemd.cuda"]
-        elif self.sander:
-            cmd=["sander"]
-
-        if self.amber_flags:
-            for flag_key, flag_value in self.amber_flags.items():
-                if flag_value is None:
-                    continue
-                if len(flag_key) == 1:
-                    cmd.append(f"-{flag_key} {flag_value}")
-                else:
-                    cmd.append(f"--{flag_key} {flag_value}")
-        
-        return cmd
-
-    def propagate(self,segment): #!would need to list all gpus and work manager index so taht there is no overlap within runseg
-        start_time = time.time()
-
-        cmd=self.construct_command()
-
-        #print(f"Executing command: {cmd} ")
-
-        #Execute the command and capture output, handling exceptions
-        try:
-            res = subprocess.run(cmd, capture_output=True, text=True) #!need to pass the variables here for amber to not use redudnat gpu usage
-        except Exception as e:
-            segment.mark_as_failed(str(e))
-            return segment
-
-
-        segment_dir = self.segment_dir_template.format(n_iter=segment.n_iter, seg_id=segment.seg_id)
-        os.makedirs(segment_dir)
-        final_state_file = os.path.join(segment_dir,self.restart)
-        segment.final_state = State(file=final_state_file)
-        segment.walltime = time.time() - start_time #done
-        return segment
-
-
-
-
-
-
-
-#$PMEMD -O -p parent.prmtop -i prod.in -c parent.rst -o seg.out -inf seg.nfo -l seg.log -x seg.nc -r seg.rst || exit 1
+"""
+        #returning a bash script that will be run
+        return bash_script

--- a/src/westpa/core/propagators/_amber.py
+++ b/src/westpa/core/propagators/_amber.py
@@ -1,0 +1,128 @@
+import logging
+import subprocess 
+import copy
+import logging
+import os
+import time
+from dataclasses import dataclass
+
+import numpy as np
+import openmm.app
+
+from .base import Propagator
+from westpa.core.state import State
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SEGMENT_DIR_TEMPLATE = 'traj_segs/{n_iter:06d}/{seg_id:06d}'
+DEFAULT_FINAL_STATE_FILENAME = 'final_state.xml'
+
+class Amberropagator(Propagator):
+    """
+    Work in progress Amber propagation engine 
+
+    """
+
+    def __init__(
+        self,
+        mdin,
+        inpcrd,
+        mdcrd,
+        mdout=None,
+        mdinfo=None,
+        prmtop=None,
+        refc=None,
+        mtmd=None,
+        mdcrt=None,
+        inptraj=None,
+        mdvel=None,
+        mdfrc=None,
+        mden=None,
+        restrt=None,
+        inpdip=None,
+        rstdip=None,
+        cpin=None,
+        cpestrt=None,
+        cpout=None,
+        cein=None,
+        ceresrst=None,
+        cecout=None,
+        evbin=None,
+        suffix=None,
+        segment_dir_template=None,
+        final_state_filename=None,
+        root_seed=None,
+        **kwargs
+    ):
+        super().__init__()
+        self.mdin = mdin
+        self.mdout = mdout
+        self.mdinfo = mdinfo
+        self.prmtop = prmtop
+        self.inpcrd = inpcrd
+        self.refc = refc
+        self.mtmd = mtmd
+        self.mdcrt = mdcrt
+        self.inptraj = inptraj
+        self.mdvel = mdvel
+        self.mdfrc = mdfrc
+        self.mden = mden
+        self.restrt = restrt
+        self.inpdip = inpdip
+        self.rstdip = rstdip
+        self.cpin = cpin
+        self.cpestrt = cpestrt
+        self.cpout = cpout
+        self.cein = cein
+        self.ceresrst = ceresrst
+        self.cecout = cecout
+        self.evbin = evbin
+        self.suffix = suffix
+        #!Figure out if **kwargs
+
+        #self.platform_properties = platform_properties
+        #self.segment_dir_template = os.path.abspath(segment_dir_template or DEFAULT_SEGMENT_DIR_TEMPLATE)
+        #self.final_state_filename = final_state_filename or DEFAULT_FINAL_STATE_FILENAME
+        #self._reports = []
+
+
+    def propagate(self,segment):
+        start_time = time.time()
+        #Command construction
+        input_flags=vars(self)
+        cmd=["pmemd.cuda"]
+        for k, v in input_flags.items():
+            
+            if v is None:
+                #print(k) #all the ones that are none
+                continue
+
+            if k == "_root_seed":
+                continue
+            if k == "_block_size":
+                continue
+            
+            cmd.append(f"--{k} {v}")
+        #print(cmd)
+
+        #command execution
+        res = subprocess.run(cmd, capture_output=True, text=True)
+
+        state=segment.initial_state.file #file in storage that md will pick up from #!This is specified with input flag, c 
+        segment_dir = self.segment_dir_template.format(n_iter=segment.n_iter, seg_id=segment.seg_id)
+        os.makedirs(segment_dir)
+
+        final_state_file = os.path.join(segment_dir, self.mdcrd) #aka seg.nc 
+        segment.final_state = State(file=final_state_file)
+        segment.walltime = time.time() - start_time #done
+
+        return segment
+
+
+
+
+
+
+
+#$PMEMD -O -p parent.prmtop -i prod.in -c parent.rst -o seg.out -inf seg.nfo -l seg.log -x seg.nc -r seg.rst || exit 1
+

--- a/src/westpa/core/propagators/_amber.py
+++ b/src/westpa/core/propagators/_amber.py
@@ -1,6 +1,5 @@
 import logging
 import subprocess
-from .base import Propagator
 from .subprocess import SubprocessPropagator
 from ..state import State
 import time

--- a/src/westpa/core/propagators/_gromacs.py
+++ b/src/westpa/core/propagators/_gromacs.py
@@ -1,0 +1,62 @@
+import os
+
+import numpy as np
+
+from .subprocess import SubprocessPropagator
+
+
+class GromacsPropagator(SubprocessPropagator):
+    """Molecular dynamics propagator built on the `GROMACS <https://www.gromacs.org/>`_ package.
+
+    Parameters
+    ----------
+    topology_file : str
+    md_parameters : Mapping[str, Any]
+    ref_structure_file : str, optional
+    ref_b_structure_file : str, optional
+    index_file : str, optional
+    final_state_filename : str, optional
+    **kwargs
+
+    """
+
+    DEFAULT_FINAL_STATE_FILENAME = 'confout.gro'
+
+    def __init__(
+        self,
+        topology_file,
+        md_parameters,
+        ref_coordinate_file=None,
+        ref_b_coordinate_file=None,
+        index_file=None,
+        final_state_filename=None,
+        **kwargs,
+    ):
+        self.topology_file = os.path.abspath(topology_file)
+        self.md_parameters = dict(md_parameters)
+
+        self.ref_coordinate_file = os.path.abspath(ref_coordinate_file) if ref_coordinate_file else None
+        self.ref_b_coordinate_file = os.path.abspath(ref_b_coordinate_file) if ref_b_coordinate_file else None
+        self.index_file = os.path.abspath(index_file) if index_file else None
+
+        final_state_filename = final_state_filename or self.DEFAULT_FINAL_STATE_FILENAME
+        super().__init__(final_state_filename=final_state_filename, **kwargs)
+
+    def get_command(self, segment, rng):
+        md_parameters = self.md_parameters | {'ld-seed': rng.integers(2**16, dtype=np.uint16)}
+        grompp_args = {
+            'c': segment.initial_state.file,
+            'p': self.topology_file,
+            'r': self.ref_coordinate_file,
+            'rb': self.ref_b_coordinate_file,
+            'ndx': self.index_file,
+        }
+
+        md_parameters = '\n'.join(f'{k} = {v}' for k, v in md_parameters.items())
+        grompp_args = ' '.join(f'-{k} {v}' for k, v in grompp_args.items() if v is not None)
+
+        return f"""\
+printf "{md_parameters}" >grompp.mdp
+gmx grompp {grompp_args}
+gmx mdrun -c {self.final_state_filename} -nt 1
+"""

--- a/src/westpa/core/propagators/_openmm.py
+++ b/src/westpa/core/propagators/_openmm.py
@@ -24,10 +24,10 @@ class OpenMMPropagator(Propagator):
 
     To create a :class:`~westpa.State` object compatible with this propagator,
     write an OpenMM State object to an XML file (e.g., ``state.xml``) and pass
-    the absolute path to the `file` parameter::
+    the absolute path to the `file` parameter:
 
-        >>> import westpa
-        >>> state = westpa.State(file='/path/to/state.xml')
+    >>> import westpa
+    >>> state = westpa.State(file='/path/to/state.xml')
 
     Parameters
     ----------

--- a/src/westpa/core/propagators/base.py
+++ b/src/westpa/core/propagators/base.py
@@ -83,7 +83,11 @@ class Propagator:
 
         if segment_dir_template is None:
             segment_dir_template = self.DEFAULT_SEGMENT_DIR_TEMPLATE
-        segment_dir_template = os.path.abspath(segment_dir_template)
+        else:
+            try:
+                segment_dir_template.format(n_iter=1, seg_id=0)
+            except ValueError:
+                raise
 
         if root_seed is None:
             root_seed = secrets.randbits(128)
@@ -101,7 +105,7 @@ class Propagator:
             raise TypeError("'bit_generator_type' must be a subclass of numpy.random.BitGenerator")
 
         self._block_size = block_size
-        self._segment_dir_template = segment_dir_template
+        self._segment_dir_template = os.path.abspath(segment_dir_template)
         self._root_seed = root_seed
         self._bit_generator_type = bit_generator_type
 
@@ -193,14 +197,12 @@ class Propagator:
             for segment in segments:
                 rng = self._get_rng(segment)
                 start_walltime = time.perf_counter()
-                start_cputime = time.process_time()
                 try:
                     segment = self.propagate(segment, rng)
                 except Exception:
                     segment.mark_as_failed(traceback.format_exc())
                 else:
                     segment.walltime = time.perf_counter() - start_walltime
-                    segment.cputime = time.process_time() - start_cputime
         else:
             rng = self._get_rng(segments[0])
             segments = self.propagate_block(segments, rng)

--- a/src/westpa/core/propagators/base.py
+++ b/src/westpa/core/propagators/base.py
@@ -9,7 +9,8 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
-#class PropagatorError()
+# class PropagatorError()
+
 
 class _PropagatorBase(ABC):
     DEFAULT_SEGMENT_DIR_TEMPLATE = 'traj_segs/{n_iter:06d}/{seg_id:06d}'

--- a/src/westpa/core/propagators/base.py
+++ b/src/westpa/core/propagators/base.py
@@ -8,6 +8,7 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
+#class PropagatorError()
 
 class Propagator:
     """Base class for propagators. Subclasses must override either the

--- a/src/westpa/core/propagators/subprocess.py
+++ b/src/westpa/core/propagators/subprocess.py
@@ -1,0 +1,116 @@
+import abc
+import os
+import signal
+import subprocess
+
+from .base import Propagator
+from ..state import State
+
+
+class SubprocessPropagator(Propagator):
+    """Propagates a trajectory segment by running an external program.
+    The program is executed in the directory created by the
+    :meth:`make_segment_dir` method.
+
+    Subclasses must implement the :meth:`get_command` method.
+
+    Parameters
+    ----------
+    final_state_filename : str
+        Name of the file used to store the final state of each segment (e.g.,
+        ``'final_state.rst'``).
+    stdout : str or io.TextIOBase, optional
+        File or stream to redirect stdout to. If a string is passed, it must
+        be a path template containing ``{n_iter}`` and ``{seg_id}`` replacement
+        fields. If None, no output will be captured.
+    stderr : str or io.TextIOBase, optional
+        File or stream to redirect stderr to. If a string is passed, it must
+        be a path template containing ``{n_iter}`` and ``{seg_id}`` replacement
+        fields. If None, no output will be captured.
+    shell : bool, default True
+        If True, the string returned by the :meth:`get_command` method will be
+        executed through the shell. If False, the string must be the name of a
+        program to execute.
+    **kwargs
+        Parameters to pass to the :class:`Propagator` base class constructor.
+
+    """
+
+    def __init__(
+        self,
+        final_state_filename,
+        stdout=None,
+        stderr=None,
+        shell=True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.final_state_filename = final_state_filename
+        self.stdout = os.path.abspath(stdout) if isinstance(stdout, str) else stdout
+        self.stderr = os.path.abspath(stderr) if isinstance(stderr, str) else stderr
+        self.shell = shell
+
+    @abc.abstractmethod
+    def get_command(self, segment, rng):
+        """ "Return the command to execute for a given segment.
+
+        Parameters
+        ----------
+        segment : :class:`Segment`
+            Segment to propagate.
+        rng : numpy.random.Generator
+            Pseudo-random number generator for seeding the stochastic dynamics
+            engine.
+
+        Returns
+        -------
+        command : str
+            Command to execute for the given segment. It must write the final
+            state of the segment to ``self.final_state_filename``.
+
+        """
+        ...
+
+    def propagate(self, segment, rng):
+        segment_dir = self.make_segment_dir(segment)
+        command = self.get_command(segment, rng)
+
+        if isinstance(self.stdout, str):
+            stdout = self.stdout.format(n_iter=segment.n_iter, seg_id=segment.seg_id)
+        else:
+            stdout = self.stdout
+        if isinstance(self.stderr, str):
+            stderr = self.stderr.format(n_iter=segment.n_iter, seg_id=segment.seg_id)
+        else:
+            stderr = self.stderr
+
+        process = subprocess.Popen(
+            command,
+            shell=self.shell,
+            stdout=stdout,
+            stderr=stderr,
+            cwd=segment_dir,
+            close_fds=True,
+        )
+
+        options = 0
+        pid, status, rusage = os.wait4(process.pid, options)
+
+        if (rc := process.wait()) == 0:
+            final_state_file = os.path.join(segment_dir, self.final_state_filename)
+            if os.path.exists(final_state_file):
+                segment.final_state = State(file=final_state_file)
+            else:
+                raise RuntimeError(f"final state must be written to {final_state_file}")
+        elif rc < 0:
+            signum = -rc
+            description = signal.strsignal(signum)
+            reason = 'child process for segment %d exited on signal %d (%s)' % (segment.seg_id, signum, description)
+            segment.mark_as_failed(reason)
+        else:
+            reason = 'child process for segment %d exited with code %d' % (segment.seg_id, rc)
+            segment.mark_as_failed(reason)
+
+        segment.cputime = rusage.ru_utime
+
+        return segment

--- a/src/westpa/core/propagators/subprocess.py
+++ b/src/westpa/core/propagators/subprocess.py
@@ -22,11 +22,11 @@ class SubprocessPropagator(Propagator):
     stdout : str or io.TextIOBase, optional
         File or stream to redirect stdout to. If a string is passed, it must
         be a path template containing ``{n_iter}`` and ``{seg_id}`` replacement
-        fields. If None, no output will be captured.
+        fields. If None, no redirection will occur.
     stderr : str or io.TextIOBase, optional
         File or stream to redirect stderr to. If a string is passed, it must
         be a path template containing ``{n_iter}`` and ``{seg_id}`` replacement
-        fields. If None, no output will be captured.
+        fields. If None, no redirection will occur.
     shell : bool, default True
         If True, the string returned by the :meth:`get_command` method will be
         executed through the shell. If False, the string must be the name of a

--- a/src/westpa/core/propagators/subprocess.py
+++ b/src/westpa/core/propagators/subprocess.py
@@ -7,7 +7,6 @@ from .base import SerialPropagator
 from ..state import State
 
 
-
 class SubprocessPropagator(SerialPropagator):
     """Propagates a trajectory segment by running an external program.
     The program is executed in the directory created by the

--- a/src/westpa/core/propagators/subprocess.py
+++ b/src/westpa/core/propagators/subprocess.py
@@ -3,11 +3,12 @@ import os
 import signal
 import subprocess
 
-from .base import Propagator
+from .base import SerialPropagator
 from ..state import State
 
 
-class SubprocessPropagator(Propagator):
+
+class SubprocessPropagator(SerialPropagator):
     """Propagates a trajectory segment by running an external program.
     The program is executed in the directory created by the
     :meth:`make_segment_dir` method.

--- a/tests/test_propagators/test_amber.py
+++ b/tests/test_propagators/test_amber.py
@@ -1,9 +1,7 @@
 import os
 import re
 import stat
-
 import pytest
-
 import westpa
 from westpa.core.propagators._amber import AmberPropagator
 from westpa.core.sim_manager import PropagationError
@@ -47,13 +45,13 @@ def propagator(prmtop_file, tmp_path):
 def test_default_final_state_filename(propagator):
     assert propagator.final_state_filename == 'restrt'
 
-# When enginge is not a valid option
+# When engine is not a valid option
 def test_invalid_engine_raises(propagator, newtraj_segment):
     propagator.engine = 'not_a_real_engine'
     with pytest.raises(PropagationError, match='not a valid'):
         propagator.get_command(newtraj_segment, rng=None)
 
-# When enginge is not found on Path
+# When engine is not found on Path
 def test_engine_not_on_path_raises(propagator, newtraj_segment, monkeypatch):
     monkeypatch.setattr('shutil.which', lambda engine: None)
     with pytest.raises(PropagationError, match='not found in PATH'):
@@ -64,7 +62,7 @@ def test_engine_name_is_lowercased(prmtop_file):
     propagator = AmberPropagator(md_parameters={}, prmtop_file=str(prmtop_file), engine='SANDER')
     assert propagator.engine == 'sander'
 
-# checks that given a correctly constructred path from shutil.which the command correctly includes the enginge name in the command
+# checks that given a correctly constructed path from shutil.which the command correctly includes the engine name in the command
 @pytest.mark.parametrize('engine', ['sander', 'pmemd', 'pmemd.cuda'])
 def test_valid_engines_accepted(prmtop_file, initial_state, engine, monkeypatch):
     monkeypatch.setattr('shutil.which', lambda engine: f'/usr/bin/{engine}')
@@ -75,7 +73,7 @@ def test_valid_engines_accepted(prmtop_file, initial_state, engine, monkeypatch)
     assert engine in command
 
 
-# checks that given a correctly constructred path from shutil.which the command correctly includes the -p and -c flags 
+# checks that given a correctly constructed path from shutil.which the command correctly includes the -p and -c flags
 def test_command_contains_topology_and_initial_state(propagator, newtraj_segment, prmtop_file, monkeypatch):
     monkeypatch.setattr('shutil.which', lambda engine: '/usr/bin/sander')
     rng = propagator._get_rng(newtraj_segment)
@@ -132,6 +130,7 @@ def fake_sander(tmp_path, monkeypatch):
     script.chmod(script.stat().st_mode | stat.S_IEXEC)
     monkeypatch.setenv('PATH', f'{bin_dir}{os.pathsep}{os.environ["PATH"]}')
 
+#Full test it circumvents calling sander and just creates the expected restart file, it then checks other variables are set
 def test_call_produces_final_state(propagator, newtraj_segment, fake_sander):
     segments = propagator([newtraj_segment])
     segment = segments[0]

--- a/tests/test_propagators/test_amber.py
+++ b/tests/test_propagators/test_amber.py
@@ -8,29 +8,36 @@ import westpa
 from westpa.core.propagators._amber import AmberPropagator
 from westpa.core.sim_manager import PropagationError
 
+
 @pytest.fixture
 def prmtop_file(tmp_path):
     return tmp_path / 'system.prmtop'
+
 
 @pytest.fixture
 def initial_state(tmp_path):
     return westpa.State(file=tmp_path / 'initial.rst')
 
+
 def make_segment(initial_state, n_iter, seg_id, parent_id):
     return westpa.Segment(n_iter=n_iter, seg_id=seg_id, parent_id=parent_id, initial_state=initial_state)
+
 
 @pytest.fixture
 def newtraj_segment(initial_state):
     return make_segment(initial_state, n_iter=1, seg_id=0, parent_id=-1)
 
+
 @pytest.fixture
 def continues_segment(initial_state):
     return make_segment(initial_state, n_iter=2, seg_id=0, parent_id=0)
+
 
 def get_ig(command):
     match = re.search(r'ig\s*=\s*(\d+)', command)
     assert match is not None, 'expected an ig= entry in the mdin block'
     return int(match.group(1))
+
 
 @pytest.fixture
 def propagator(prmtop_file, tmp_path):
@@ -42,10 +49,13 @@ def propagator(prmtop_file, tmp_path):
         segment_dir_template=os.path.join(tmp_path, '{n_iter:06d}', '{seg_id:06d}'),
     )
 
+
 # ---- defaults ----
+
 
 def test_default_final_state_filename(propagator):
     assert propagator.final_state_filename == 'restrt'
+
 
 # When enginge is not a valid option
 def test_invalid_engine_raises(propagator, newtraj_segment):
@@ -53,16 +63,19 @@ def test_invalid_engine_raises(propagator, newtraj_segment):
     with pytest.raises(PropagationError, match='not a valid'):
         propagator.get_command(newtraj_segment, rng=None)
 
+
 # When enginge is not found on Path
 def test_engine_not_on_path_raises(propagator, newtraj_segment, monkeypatch):
     monkeypatch.setattr('shutil.which', lambda engine: None)
     with pytest.raises(PropagationError, match='not found in PATH'):
         propagator.get_command(newtraj_segment, rng=None)
 
+
 # Ensures engine names are always converted to lower case
 def test_engine_name_is_lowercased(prmtop_file):
     propagator = AmberPropagator(md_parameters={}, prmtop_file=str(prmtop_file), engine='SANDER')
     assert propagator.engine == 'sander'
+
 
 # checks that given a correctly constructred path from shutil.which the command correctly includes the enginge name in the command
 @pytest.mark.parametrize('engine', ['sander', 'pmemd', 'pmemd.cuda'])
@@ -75,7 +88,7 @@ def test_valid_engines_accepted(prmtop_file, initial_state, engine, monkeypatch)
     assert engine in command
 
 
-# checks that given a correctly constructred path from shutil.which the command correctly includes the -p and -c flags 
+# checks that given a correctly constructred path from shutil.which the command correctly includes the -p and -c flags
 def test_command_contains_topology_and_initial_state(propagator, newtraj_segment, prmtop_file, monkeypatch):
     monkeypatch.setattr('shutil.which', lambda engine: '/usr/bin/sander')
     rng = propagator._get_rng(newtraj_segment)
@@ -83,7 +96,8 @@ def test_command_contains_topology_and_initial_state(propagator, newtraj_segment
     assert f'-p {prmtop_file}' in command
     assert f'-c {newtraj_segment.initial_state.file}' in command
 
-#check that the header of the mdin file contains the correct title 
+
+# check that the header of the mdin file contains the correct title
 def test_title_reflects_segment(propagator, newtraj_segment, monkeypatch):
     monkeypatch.setattr('shutil.which', lambda engine: '/usr/bin/sander')
     rng = propagator._get_rng(newtraj_segment)
@@ -93,6 +107,7 @@ def test_title_reflects_segment(propagator, newtraj_segment, monkeypatch):
 
 # ---- mdin / restart logic ----
 
+
 # ensures the command contains the correct irest and ntx flags for a new segment
 def test_newtraj_segment_sets_fresh_start_flags(propagator, newtraj_segment, monkeypatch):
     monkeypatch.setattr('shutil.which', lambda engine: '/usr/bin/sander')
@@ -100,6 +115,7 @@ def test_newtraj_segment_sets_fresh_start_flags(propagator, newtraj_segment, mon
     command = propagator.get_command(newtraj_segment, rng)
     assert 'irest = 0' in command
     assert 'ntx = 1' in command
+
 
 # ensures the command contains the correct irest and ntx flags for a continuing a segment
 def test_continues_segment_sets_restart_flags(propagator, continues_segment, monkeypatch):
@@ -109,18 +125,21 @@ def test_continues_segment_sets_restart_flags(propagator, continues_segment, mon
     assert 'irest = 1' in command
     assert 'ntx = 5' in command
 
+
 def test_seed_is_reproducible_for_same_segment(propagator, newtraj_segment, monkeypatch):
     monkeypatch.setattr('shutil.which', lambda engine: '/usr/bin/sander')
     ig_1 = get_ig(propagator.get_command(newtraj_segment, propagator._get_rng(newtraj_segment)))
     ig_2 = get_ig(propagator.get_command(newtraj_segment, propagator._get_rng(newtraj_segment)))
     assert ig_1 == ig_2
 
-#ensures writing the command does not overwrite the input variables in memory, only a copy 
+
+# ensures writing the command does not overwrite the input variables in memory, only a copy
 def test_md_parameters_not_mutated(propagator, newtraj_segment, monkeypatch):
     monkeypatch.setattr('shutil.which', lambda engine: '/usr/bin/sander')
     original = propagator.md_parameters.copy()
     propagator.get_command(newtraj_segment, propagator._get_rng(newtraj_segment))
     assert propagator.md_parameters == original
+
 
 @pytest.fixture
 def fake_sander(tmp_path, monkeypatch):
@@ -131,6 +150,7 @@ def fake_sander(tmp_path, monkeypatch):
     script.write_text('#!/bin/sh\necho fake_restart > restrt\n')
     script.chmod(script.stat().st_mode | stat.S_IEXEC)
     monkeypatch.setenv('PATH', f'{bin_dir}{os.pathsep}{os.environ["PATH"]}')
+
 
 def test_call_produces_final_state(propagator, newtraj_segment, fake_sander):
     segments = propagator([newtraj_segment])

--- a/tests/test_propagators/test_amber.py
+++ b/tests/test_propagators/test_amber.py
@@ -1,0 +1,140 @@
+import os
+import re
+import stat
+
+import pytest
+
+import westpa
+from westpa.core.propagators._amber import AmberPropagator
+from westpa.core.sim_manager import PropagationError
+
+@pytest.fixture
+def prmtop_file(tmp_path):
+    return tmp_path / 'system.prmtop'
+
+@pytest.fixture
+def initial_state(tmp_path):
+    return westpa.State(file=tmp_path / 'initial.rst')
+
+def make_segment(initial_state, n_iter, seg_id, parent_id):
+    return westpa.Segment(n_iter=n_iter, seg_id=seg_id, parent_id=parent_id, initial_state=initial_state)
+
+@pytest.fixture
+def newtraj_segment(initial_state):
+    return make_segment(initial_state, n_iter=1, seg_id=0, parent_id=-1)
+
+@pytest.fixture
+def continues_segment(initial_state):
+    return make_segment(initial_state, n_iter=2, seg_id=0, parent_id=0)
+
+def get_ig(command):
+    match = re.search(r'ig\s*=\s*(\d+)', command)
+    assert match is not None, 'expected an ig= entry in the mdin block'
+    return int(match.group(1))
+
+@pytest.fixture
+def propagator(prmtop_file, tmp_path):
+    return AmberPropagator(
+        md_parameters={'nstlim': 100, 'dt': 0.002},
+        prmtop_file=str(prmtop_file),
+        engine='sander',
+        root_seed=12345,
+        segment_dir_template=os.path.join(tmp_path, '{n_iter:06d}', '{seg_id:06d}'),
+    )
+
+# ---- defaults ----
+
+def test_default_final_state_filename(propagator):
+    assert propagator.final_state_filename == 'restrt'
+
+# When enginge is not a valid option
+def test_invalid_engine_raises(propagator, newtraj_segment):
+    propagator.engine = 'not_a_real_engine'
+    with pytest.raises(PropagationError, match='not a valid'):
+        propagator.get_command(newtraj_segment, rng=None)
+
+# When enginge is not found on Path
+def test_engine_not_on_path_raises(propagator, newtraj_segment, monkeypatch):
+    monkeypatch.setattr('shutil.which', lambda engine: None)
+    with pytest.raises(PropagationError, match='not found in PATH'):
+        propagator.get_command(newtraj_segment, rng=None)
+
+# Ensures engine names are always converted to lower case
+def test_engine_name_is_lowercased(prmtop_file):
+    propagator = AmberPropagator(md_parameters={}, prmtop_file=str(prmtop_file), engine='SANDER')
+    assert propagator.engine == 'sander'
+
+# checks that given a correctly constructred path from shutil.which the command correctly includes the enginge name in the command
+@pytest.mark.parametrize('engine', ['sander', 'pmemd', 'pmemd.cuda'])
+def test_valid_engines_accepted(prmtop_file, initial_state, engine, monkeypatch):
+    monkeypatch.setattr('shutil.which', lambda engine: f'/usr/bin/{engine}')
+    propagator = AmberPropagator(md_parameters={}, prmtop_file=str(prmtop_file), engine=engine, root_seed=1)
+    segment = make_segment(initial_state, n_iter=1, seg_id=0, parent_id=-1)
+    rng = propagator._get_rng(segment)
+    command = propagator.get_command(segment, rng)
+    assert engine in command
+
+
+# checks that given a correctly constructred path from shutil.which the command correctly includes the -p and -c flags 
+def test_command_contains_topology_and_initial_state(propagator, newtraj_segment, prmtop_file, monkeypatch):
+    monkeypatch.setattr('shutil.which', lambda engine: '/usr/bin/sander')
+    rng = propagator._get_rng(newtraj_segment)
+    command = propagator.get_command(newtraj_segment, rng)
+    assert f'-p {prmtop_file}' in command
+    assert f'-c {newtraj_segment.initial_state.file}' in command
+
+#check that the header of the mdin file contains the correct title 
+def test_title_reflects_segment(propagator, newtraj_segment, monkeypatch):
+    monkeypatch.setattr('shutil.which', lambda engine: '/usr/bin/sander')
+    rng = propagator._get_rng(newtraj_segment)
+    command = propagator.get_command(newtraj_segment, rng)
+    assert f'n_iter={newtraj_segment.n_iter}, seg_id={newtraj_segment.seg_id}' in command
+
+
+# ---- mdin / restart logic ----
+
+# ensures the command contains the correct irest and ntx flags for a new segment
+def test_newtraj_segment_sets_fresh_start_flags(propagator, newtraj_segment, monkeypatch):
+    monkeypatch.setattr('shutil.which', lambda engine: '/usr/bin/sander')
+    rng = propagator._get_rng(newtraj_segment)
+    command = propagator.get_command(newtraj_segment, rng)
+    assert 'irest = 0' in command
+    assert 'ntx = 1' in command
+
+# ensures the command contains the correct irest and ntx flags for a continuing a segment
+def test_continues_segment_sets_restart_flags(propagator, continues_segment, monkeypatch):
+    monkeypatch.setattr('shutil.which', lambda engine: '/usr/bin/sander')
+    rng = propagator._get_rng(continues_segment)
+    command = propagator.get_command(continues_segment, rng)
+    assert 'irest = 1' in command
+    assert 'ntx = 5' in command
+
+def test_seed_is_reproducible_for_same_segment(propagator, newtraj_segment, monkeypatch):
+    monkeypatch.setattr('shutil.which', lambda engine: '/usr/bin/sander')
+    ig_1 = get_ig(propagator.get_command(newtraj_segment, propagator._get_rng(newtraj_segment)))
+    ig_2 = get_ig(propagator.get_command(newtraj_segment, propagator._get_rng(newtraj_segment)))
+    assert ig_1 == ig_2
+
+#ensures writing the command does not overwrite the input variables in memory, only a copy 
+def test_md_parameters_not_mutated(propagator, newtraj_segment, monkeypatch):
+    monkeypatch.setattr('shutil.which', lambda engine: '/usr/bin/sander')
+    original = propagator.md_parameters.copy()
+    propagator.get_command(newtraj_segment, propagator._get_rng(newtraj_segment))
+    assert propagator.md_parameters == original
+
+@pytest.fixture
+def fake_sander(tmp_path, monkeypatch):
+    """Stubs out `sander` on PATH with a script that just writes a restrt file."""
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir()
+    script = bin_dir / 'sander'
+    script.write_text('#!/bin/sh\necho fake_restart > restrt\n')
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    monkeypatch.setenv('PATH', f'{bin_dir}{os.pathsep}{os.environ["PATH"]}')
+
+def test_call_produces_final_state(propagator, newtraj_segment, fake_sander):
+    segments = propagator([newtraj_segment])
+    segment = segments[0]
+    assert segment.status == westpa.Segment.Status.COMPLETE
+    assert os.path.exists(segment.final_state.file)
+    assert segment.cputime > 0

--- a/tests/test_propagators/test_subprocess.py
+++ b/tests/test_propagators/test_subprocess.py
@@ -1,0 +1,39 @@
+import os
+
+import pytest
+
+import westpa
+from westpa.core.propagators.subprocess import SubprocessPropagator
+
+
+class TestPropagator(SubprocessPropagator):
+    """Creates a symlink from the final state file to the initial state file."""
+
+    def get_command(self, segment, rng):
+        return f'ln -s {segment.initial_state.file} {self.final_state_filename}'
+
+
+@pytest.fixture
+def propagator(tmp_path):
+    return TestPropagator(
+        final_state_filename='final_state.npy',
+        segment_dir_template=os.path.join(tmp_path, '{n_iter:06d}', '{seg_id:06d}'),
+    )
+
+
+@pytest.fixture
+def initial_state(tmp_path):
+    file = tmp_path / "initial_state.npy"
+    return westpa.State(file=file)
+
+
+@pytest.fixture
+def segment(initial_state):
+    return westpa.Segment(n_iter=1, seg_id=0, initial_state=initial_state)
+
+
+def test_call(propagator, segment):
+    segments = propagator([segment])
+    segment = segments[0]
+    assert os.readlink(segment.final_state.file) == segment.initial_state.file
+    assert segment.cputime > 0


### PR DESCRIPTION
## Issue Number
N/A

## Describe the changes made
Added an `AmberPropagator` for running MD segments through Amber's `sander`, `pmemd`, or `pmemd.cuda` engines. This builds on a new `SubprocessPropagator` base class.

## Goals and Outstanding Issues

- [ ] `AmberPropagator.get_command()` raises `PropagationError` for an invalid/missing engine, but is followed by a second, unreachable `raise PropagatorError(...)` — `PropagatorError` which I think should be added 

## Major files changed
- `src/westpa/core/propagators/_amber.py` — new `AmberPropagator`
- `tests/test_propagators/test_amber.py` — new test suite (14 tests)

## Status

- [x] New feature (non-breaking change which adds functionality)
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


